### PR TITLE
Add comprehensive Jest test coverage

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -4,8 +4,9 @@ const bcrypt=require('bcrypt');
 var crypto=require('crypto');
 const user = require("../models/user");
 const algorithm = 'aes256';
-const key=process.env.secretKey;
-import { Resend } from 'resend';
+const key = process.env.secretKey;
+// use commonjs import for resend to avoid ESM issues
+const { Resend } = require('resend');
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 

--- a/tests/controllers/loggedinController.test.js
+++ b/tests/controllers/loggedinController.test.js
@@ -1,0 +1,36 @@
+// Tests for protected route
+jest.mock('../../authenticate', () => ({
+  verifyUser: jest.fn((req, res, next) => {
+    req.user = { firstname: 'John' };
+    next();
+  }),
+  isVerifiedUser: jest.fn((req, res, next) => next()),
+  verifyAdmin: jest.fn((req, res, next) => next())
+}));
+
+jest.mock('../../models/user', () => jest.fn());
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({ emails: { send: jest.fn() } }))
+}), { virtual: true });
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  Promise: global.Promise,
+}));
+
+const request = require('supertest');
+const app = require('../../app');
+const auth = require('../../authenticate');
+
+describe('GET /home/index', () => {
+  it('returns welcome message when authenticated', async () => {
+    const res = await request(app).get('/home/index');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.msg).toMatch(/Welcome John/i);
+  });
+
+  it('returns unauthorized when middleware denies', async () => {
+    auth.verifyUser.mockImplementationOnce((req, res) => res.status(401).json({ error: 'Unauthorized !!' }));
+    const res = await request(app).get('/home/index');
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/controllers/userController.test.js
+++ b/tests/controllers/userController.test.js
@@ -1,0 +1,202 @@
+// Comprehensive tests for user controller routes
+jest.mock('../../models/user', () => {
+  const User = jest.fn();
+  User.findOne = jest.fn();
+  User.find = jest.fn();
+  User.deleteOne = jest.fn();
+  return User;
+});
+
+jest.mock('resend', () => {
+  return {
+    Resend: jest.fn().mockImplementation(() => ({
+      emails: { send: jest.fn().mockResolvedValue(true) }
+    }))
+  };
+}, { virtual: true });
+
+// mock mongoose to avoid db connection when app loads
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  Promise: global.Promise,
+}));
+
+jest.mock('../../authenticate', () => ({
+  verifyUser: jest.fn((req, res, next) => {
+    req.user = { firstname: 'John', admin: true, tokens: [], save: jest.fn().mockResolvedValue(true) };
+    req.token = '';
+    next();
+  }),
+  verifyAdmin: jest.fn((req, res, next) => {
+    if (req.user && req.user.admin) return next();
+    return res.status(401).json({ error: 'Admin access required !!' });
+  }),
+  isVerifiedUser: jest.fn((req, res, next) => next())
+}));
+
+jest.mock('bcrypt', () => ({
+  genSalt: jest.fn().mockResolvedValue('salt'),
+  hash: jest.fn().mockResolvedValue('hashedPassword'),
+  compare: jest.fn(),
+}));
+
+const request = require('supertest');
+const app = require('../../app');
+const User = require('../../models/user');
+const auth = require('../../authenticate');
+const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+
+const algorithm = 'aes256';
+
+function generateToken(id, exp) {
+  const cipher = crypto.createCipher(algorithm, process.env.secretKey);
+  let enc = cipher.update(`${id}.${exp}`, 'utf8', 'hex');
+  enc += cipher.final('hex');
+  return enc;
+}
+
+beforeEach(() => {
+  process.env.secretKey = '12345678901234567890123456789012';
+  process.env.secretkey = '12345678901234567890123456789012';
+  process.env.expire = '60000';
+  jest.clearAllMocks();
+  User.mockImplementation(() => ({ save: jest.fn().mockResolvedValue(true), tokens: [] }));
+});
+
+describe('GET /user/test-email', () => {
+  it('returns simple message', async () => {
+    const res = await request(app).get('/user/test-email');
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toMatch(/EndPoint reached/);
+  });
+});
+
+describe('GET /user/verify-email', () => {
+  it('verifies email with valid token', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    User.findOne.mockResolvedValueOnce({ emailToken: 'abc', isVerified: false, save });
+    const res = await request(app).get('/user/verify-email?token=abc');
+    expect(res.statusCode).toBe(200);
+    expect(save).toHaveBeenCalled();
+  });
+
+  it('fails with missing token', async () => {
+    const res = await request(app).get('/user/verify-email');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('fails with invalid token', async () => {
+    User.findOne.mockResolvedValueOnce(null);
+    const res = await request(app).get('/user/verify-email?token=bad');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('handles database error', async () => {
+    User.findOne.mockRejectedValueOnce(new Error('db'));
+    const res = await request(app).get('/user/verify-email?token=abc');
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe('POST /user/login', () => {
+  it('logs in successfully', async () => {
+    bcrypt.compare.mockImplementationOnce((pw, hash, cb) => cb(null, true));
+    const save = jest.fn().mockResolvedValue(true);
+    User.findOne.mockResolvedValueOnce({ _id: '1', password: 'hashedPassword', tokens: [], save });
+    const res = await request(app)
+      .post('/user/login')
+      .send({ email: 'john@example.com', password: 'secret' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBeDefined();
+    expect(save).toHaveBeenCalled();
+  });
+
+  it('fails if credentials missing', async () => {
+    const res = await request(app)
+      .post('/user/login')
+      .send({ email: 'john@example.com' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('fails when user not found', async () => {
+    User.findOne.mockResolvedValueOnce(null);
+    const res = await request(app)
+      .post('/user/login')
+      .send({ email: 'john@example.com', password: 'secret' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('fails on wrong password', async () => {
+    bcrypt.compare.mockImplementationOnce((pw, hash, cb) => cb(null, false));
+    User.findOne.mockResolvedValueOnce({ _id: '1', password: 'hashedPassword', tokens: [], save: jest.fn() });
+    const res = await request(app)
+      .post('/user/login')
+      .send({ email: 'john@example.com', password: 'wrong' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('handles bcrypt error', async () => {
+    bcrypt.compare.mockImplementationOnce((pw, hash, cb) => cb(new Error('err')));
+    User.findOne.mockResolvedValueOnce({ _id: '1', password: 'hashedPassword', tokens: [], save: jest.fn() });
+    const res = await request(app)
+      .post('/user/login')
+      .send({ email: 'john@example.com', password: 'secret' });
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe('GET /user/logout', () => {
+  it('logs out with valid token', async () => {
+    auth.verifyUser.mockImplementationOnce((req, res, next) => {
+      req.user = { tokens: [], save: jest.fn().mockResolvedValue(true) };
+      req.token = 'tok';
+      next();
+    });
+    const res = await request(app).get('/user/logout');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('fails with invalid token', async () => {
+    auth.verifyUser.mockImplementationOnce((req, res) => res.status(401).json({ error: 'Invalid Token !!' }));
+    const res = await request(app).get('/user/logout');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('fails when not logged in', async () => {
+    auth.verifyUser.mockImplementationOnce((req, res, next) => { next(); });
+    const res = await request(app).get('/user/logout');
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /user/dump', () => {
+  it('dumps users when admin', async () => {
+    auth.verifyUser.mockImplementationOnce((req, res, next) => {
+      req.user = { admin: true };
+      next();
+    });
+    User.find.mockImplementationOnce(cb => cb(null, [{ admin: false, remove: jest.fn() }, { admin: true }]));
+    const res = await request(app).get('/user/dump');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('fails when not admin', async () => {
+    auth.verifyUser.mockImplementationOnce((req, res, next) => {
+      req.user = { admin: false };
+      next();
+    });
+    const res = await request(app).get('/user/dump');
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('handles database error', async () => {
+    auth.verifyUser.mockImplementationOnce((req, res, next) => {
+      req.user = { admin: true };
+      next();
+    });
+    User.find.mockImplementationOnce(cb => cb('err'));
+    const res = await request(app).get('/user/dump');
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/tests/signup.test.js
+++ b/tests/signup.test.js
@@ -1,51 +1,71 @@
-jest.mock('@sendgrid/mail'); // ✅ Mock SendGrid
+// Updated signup tests using mocks
+jest.mock('@sendgrid/mail');
 
-const request = require("supertest");
-const app = require("../app");
-const mongoose = require("mongoose");
-const User = require("../models/user");
-
-// ✅ Set global timeout for this test suite
-jest.setTimeout(5000); // 10 seconds
-
-beforeAll(async () => {
-  process.env.SENDGRID_API_KEY = "SG.TEST_FAKE_KEY"; // dummy key
-  await mongoose.connect(process.env.DATABASE, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  });
+jest.mock('../models/user', () => {
+  const m = jest.fn();
+  m.findOne = jest.fn();
+  m.deleteOne = jest.fn();
+  m.find = jest.fn();
+  return m;
 });
 
-afterAll(async () => {
-  await User.deleteOne({ email: "testuser@example.com" }); // cleanup test user
-  await mongoose.connection.close();
+jest.mock('resend', () => {
+  return {
+    Resend: jest.fn().mockImplementation(() => ({
+      emails: { send: jest.fn().mockResolvedValue(true) }
+    }))
+  };
+}, { virtual: true });
+
+// avoid real mongoose connection
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  Promise: global.Promise,
+}));
+
+jest.mock('bcrypt', () => ({
+  genSalt: jest.fn().mockResolvedValue('salt'),
+  hash: jest.fn().mockResolvedValue('hashedPassword'),
+  compare: jest.fn(),
+}));
+
+const request = require('supertest');
+const app = require('../app');
+const User = require('../models/user');
+const bcrypt = require('bcrypt');
+
+beforeEach(() => {
+  process.env.secretKey = '12345678901234567890123456789012';
+  process.env.secretkey = '12345678901234567890123456789012';
+  process.env.expire = '60000';
+  process.env.RESEND_API_KEY = 'test';
+  jest.clearAllMocks();
+  User.mockImplementation(() => ({ save: jest.fn().mockResolvedValue(true) }));
 });
 
-describe("POST /user/signup", () => {
-  it("should register a new user successfully", async () => {
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /user/signup', () => {
+  it('should register a new user successfully', async () => {
+    User.findOne.mockResolvedValueOnce(null);
     const res = await request(app)
-      .post("/user/signup")
-      .send({
-        firstname: "Test",
-        lastname: "User",
-        email: "testuser@example.com",
-        password: "test1234"
-      });
+      .post('/user/signup')
+      .send({ firstname: 'Test', lastname: 'User', email: 'test@example.com', password: 'test1234' });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.msg).toMatch(/User Registration Successfull. Please check your email for verification link. !!/i);
+    expect(res.body.msg).toMatch(/User Registration Successfull/i);
+    expect(User).toHaveBeenCalled();
   });
 
-  it("should fail if email is missing", async () => {
+  it('should fail if email is missing', async () => {
     const res = await request(app)
-      .post("/user/signup")
-      .send({
-        firstname: "Test",
-        lastname: "User",
-        password: "test1234"
-      });
+      .post('/user/signup')
+      .send({ firstname: 'Test', lastname: 'User', password: 'test1234' });
 
     expect(res.statusCode).toBe(400);
     expect(res.body.msg).toMatch(/Either email or password field is empty/i);
   });
+
 });


### PR DESCRIPTION
## Summary
- switch resend import to CommonJS require
- rewrite signup.test to use mocks
- add user controller tests covering verify-email, login, logout and dump routes
- add logged-in controller tests for protected route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684158be2fa08333be193be567b7ae36